### PR TITLE
Quotes around code-signing identity

### DIFF
--- a/src/steps/package.js
+++ b/src/steps/package.js
@@ -5,12 +5,12 @@ var exec = require('child_process').exec;
 
 var m = {};
 
-m.buildPackage = function(app_path, identitiy, callback)
+m.buildPackage = function(app_path, identity, callback)
 {
     var dir = path.dirname(app_path);
     var app = path.basename(app_path);
     var pkg = app.replace('.app', '.pkg');
-    var command = 'cd "' + dir + '" && productbuild --component "' + app + '" /Applications --sign ' + identitiy + ' "' + pkg + '"';
+    var command = 'cd "' + dir + '" && productbuild --component "' + app + '" /Applications --sign ' + identity + ' "' + pkg + '"';
     exec(command, callback);
 };
 

--- a/src/steps/package.js
+++ b/src/steps/package.js
@@ -10,7 +10,7 @@ m.buildPackage = function(app_path, identity, callback)
     var dir = path.dirname(app_path);
     var app = path.basename(app_path);
     var pkg = app.replace('.app', '.pkg');
-    var command = 'cd "' + dir + '" && productbuild --component "' + app + '" /Applications --sign ' + identity + ' "' + pkg + '"';
+    var command = 'cd "' + dir + '" && productbuild --component "' + app + '" /Applications --sign "' + identity + '" "' + pkg + '"';
     exec(command, callback);
 };
 

--- a/src/steps/signature.js
+++ b/src/steps/signature.js
@@ -62,7 +62,7 @@ m.sign = function(app_path, identity, entitlements, callback)
 
 var _getSigningCommand = function(identity, entitlement_path, app_path)
 {
-    var command = 'codesign --deep -s ' + identity + ' --entitlements "' + entitlement_path + '"';
+    var command = 'codesign --deep -s "' + identity + '" --entitlements "' + entitlement_path + '"';
     return command + ' "' + app_path + '"';
 };
 


### PR DESCRIPTION
Hi,

Great project - it's very helpful. I noticed that the code-signing fails if an identity with spaces is provided, e.g. a fully-qualified identity like _3rd Party Mac Developer Application: Glass Echidna Pty Ltd (QUKQK3GKXK)_. 

This PR fixes that :smile: 
